### PR TITLE
Fixed the command to get the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a user-defined function which describes the process in which the custom 
 The library can be integrated by downloading the same, using the following command:
 
 ```bash
-go get github.com/openshift/operator-custom-metrics
+go get -d github.com/openshift/operator-custom-metrics
 ```
 
 ## Using operator-custom metrics library


### PR DESCRIPTION
As the package has no main.go, user must pass the `-d` flag when running `go get` so that it does not try to install it.