### PR TITLE
Fix logging string formatting

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,7 +29,7 @@ func StartMetrics(config metricsConfig) {
 	}
 
 	http.Handle(config.metricsPath, prometheus.Handler())
-	log.Info("Port: %v", config.metricsPort)
+	log.Info(fmt.Sprintf("Port: %s", config.metricsPort))
 	metricsPort := ":" + (config.metricsPort)
 	go http.ListenAndServe(metricsPort, nil)
 }

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -205,11 +206,11 @@ func createOrUpdateService(ctx context.Context, client client.Client, s *v1.Serv
 			log.Info("Error creating service object", "Error", err)
 			return nil, err
 		}
-		log.Info("Metrics Service object updated Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
+		log.Info(fmt.Sprintf("Metrics Service object updated Service.Name %v and Service.Namespace %v", s.Name, s.Namespace))
 		return existingService, nil
 	}
 
-	log.Info("Metrics Service object created Service.Name %v and Service.Namespace %v", s.Name, s.Namespace)
+	log.Info(fmt.Sprintf("Metrics Service object created Service.Name %v and Service.Namespace %v", s.Name, s.Namespace))
 	return s, nil
 }
 
@@ -232,7 +233,7 @@ func createOrUpdateRoute(ctx context.Context, client client.Client, r *routev1.R
 				log.Info("Error creating metrics route", "Error", err.Error())
 				return nil, err
 			}
-			log.Info("Metrics Route object updated Route.Name %v and Route.Namespace %v", r.Name, r.Namespace)
+			log.Info(fmt.Sprintf("Metrics Route object updated Route.Name %v and Route.Namespace %v", r.Name, r.Namespace))
 			return existingRoute, nil
 		}
 


### PR DESCRIPTION
This PR fixes some issues with string formatting when this package attempts to log messages that have been formatted. When running this package locally I'm seeing errors `"odd number of arguments passed as key-value pairs for logging"` and log statements like `{"level":"info","ts":1564757294.7398226,"logger":"userMetrics","msg":"Port: %v"}` this should resolve those issues.