### PR TITLE
Enable configuration of service name

### DIFF
--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -44,7 +44,7 @@ func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
 }
 
 //WithName specifies the name of the service
-func (b *metricsConfigBuilder) WithName(name string) *metricsConfigBuilder {
+func (b *metricsConfigBuilder) WithServiceName(name string) *metricsConfigBuilder {
 	b.config.serviceName = name
 	return b
 }

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -6,6 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 const (
 	defaultMetricsPath = "/customMetrics"
 	defaultMetricsPort = "8089"
+	defaultServiceName = "operator-metrics"
 )
 
 // metricsConfigBuilder builds a new metricsConfig object.
@@ -19,6 +20,7 @@ func NewBuilder() *metricsConfigBuilder {
 		config: metricsConfig{
 			metricsPath:   defaultMetricsPath,
 			metricsPort:   defaultMetricsPort,
+			serviceName:   defaultServiceName,
 			collectorList: nil,
 		},
 	}
@@ -38,6 +40,12 @@ func (b *metricsConfigBuilder) WithPort(port string) *metricsConfigBuilder {
 // WithPath updates the metrics path to the value provided by the user.
 func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
 	b.config.metricsPath = path
+	return b
+}
+
+//WithName specifies the name of the service
+func (b *metricsConfigBuilder) WithName(name string) *metricsConfigBuilder {
+	b.config.serviceName = name
 	return b
 }
 

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -6,6 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 type metricsConfig struct {
 	metricsPath        string
 	metricsPort        string
+	serviceName        string
 	collectorList      []prometheus.Collector
 	withRoute          bool
 	withServiceMonitor bool

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -37,7 +37,7 @@ var (
 )
 
 // GenerateService returns the static service at specified port
-func GenerateService(port int32, portName string) (*v1.Service, error) {
+func GenerateService(port int32, portName string, serviceName string) (*v1.Service, error) {
 	operatorName, err := k8sutil.GetOperatorName()
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func GenerateService(port int32, portName string) (*v1.Service, error) {
 
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatorName,
+			Name:      serviceName,
 			Namespace: namespace,
 			Labels:    map[string]string{"name": operatorName},
 		},
@@ -155,7 +155,7 @@ func ConfigureMetrics(ctx context.Context, userMetricsConfig metricsConfig) erro
 	}
 
 	res := int32(p)
-	s, svcerr := GenerateService(res, "metrics")
+	s, svcerr := GenerateService(res, "metrics", userMetricsConfig.serviceName)
 	if svcerr != nil {
 		log.Info("Error generating metrics service object.", "Error", svcerr.Error())
 		return svcerr


### PR DESCRIPTION
Set a default service name and create function for the builder that can configure the service name to a custom name. 