### PR TITLE
[TLS-Config] Enable TLS configuration for routes

### DIFF
--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -7,6 +7,8 @@ const (
 	defaultMetricsPath = "/customMetrics"
 	defaultMetricsPort = "8089"
 	defaultServiceName = "operator-metrics"
+	defaulttlsCertPath = ""
+	defaulttlsKeyPath  = ""
 )
 
 // metricsConfigBuilder builds a new metricsConfig object.
@@ -22,6 +24,8 @@ func NewBuilder() *metricsConfigBuilder {
 			metricsPort:   defaultMetricsPort,
 			serviceName:   defaultServiceName,
 			collectorList: nil,
+			tlsKeyPath:    defaulttlsKeyPath,
+			tlsCertPath:   defaulttlsCertPath,
 		},
 	}
 }
@@ -71,5 +75,17 @@ func (b *metricsConfigBuilder) WithRoute() *metricsConfigBuilder {
 
 func (b *metricsConfigBuilder) WithServiceMonitor() *metricsConfigBuilder {
 	b.config.withServiceMonitor = true
+	return b
+}
+
+// WithTLSCertPath updates the TLS certificate path with the value provided by the user
+func (b *metricsConfigBuilder) WithTLSCertPath(usertlsCertPath string) *metricsConfigBuilder {
+	b.config.tlsCertPath = usertlsCertPath
+	return b
+}
+
+// WithTLSKeyPath updates the TLS key path with the value provided by the user
+func (b *metricsConfigBuilder) WithTLSKeyPath(usertlsKeyPath string) *metricsConfigBuilder {
+	b.config.tlsCertPath = usertlsKeyPath
 	return b
 }

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -10,4 +10,6 @@ type metricsConfig struct {
 	collectorList      []prometheus.Collector
 	withRoute          bool
 	withServiceMonitor bool
+	tlsKeyPath         string
+	tlsCertPath        string
 }


### PR DESCRIPTION
This PR enables the creation of secure https connection if
the path to TLS-Certificate and TLS-Key are provided by the
user. The connection falls back to non-https, if the required
parameters are not provided.