### PR TITLE
Fix up example to compile

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -22,6 +22,10 @@ var (
 		Name: "myapp_processed_ops_total",
 		Help: "The total number of processed events Test",
 	})
+
+	metricsList = []prometheus.Collector{
+		opsProcessed,
+	}
 )
 
 // RecordMetrics updates the values of the metrics which are to be collected.
@@ -40,8 +44,9 @@ func TestConfigMetrics() {
 	prTest := metrics.NewBuilder().
 		WithPort(metricsEndPoint).
 		WithPath(metricsPath).
-		WithCollectors(opsProcessed).
-		WithMetricsFunction(RecordMetrics).
+		WithCollectors(metricsList).
+		WithServiceName("example").
+		WithRoute().
 		GetConfig()
 
 	// Start metrics server with the exposed metrics.


### PR DESCRIPTION
After the changes in #23 fixed the package issues in the example, trying to build that file showed some errors.This
1) Removes use of the WithMetricsFunction function that doesn't exist
2) Wraps the example metric in a Collector[] to ensure the right type is passed to the WithCollectors function