### PR TITLE
Fix metricsPath error

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,7 @@ github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVls
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
+github.com/operator-framework/operator-sdk v0.16.0 h1:+D61x7FjcITLzjVakzfzz5hqkkMDR+uEDMzXfyVZOw8=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Default variables for metrics-path and metrics-port.
 const (
@@ -39,6 +43,9 @@ func (b *metricsConfigBuilder) WithPort(port string) *metricsConfigBuilder {
 
 // WithPath updates the metrics path to the value provided by the user.
 func (b *metricsConfigBuilder) WithPath(path string) *metricsConfigBuilder {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
 	b.config.metricsPath = path
 	return b
 }

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -38,6 +39,11 @@ var (
 
 // GenerateService returns the static service at specified port
 func GenerateService(port int32, portName string, serviceName string) (*v1.Service, error) {
+
+	// check if portname starts with "/"
+	if strings.HasPrefix(portName, "/") {
+		portName = portName[1:]
+	}
 	operatorName, err := k8sutil.GetOperatorName()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In PR #23 we updated from kubernetes v1.13.4 to v1.15.4 which causes an error in our naming convention of our metrics service. This PR checks the port name and makes sure the correct name is rendered.

I tested with both cases "metrics" and "/metrics" on opererator-sdk version 0.15.1 & go version 1.13