### PR TITLE
Wrapper for timing Reconcile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/go.mod948676444.tmp
+++ b/go.mod948676444.tmp
@@ -8,7 +8,6 @@ require (
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/operator-framework/operator-sdk v0.12.0
 	github.com/prometheus/client_golang v1.1.0
-	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/sirupsen/logrus v1.4.2
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/pkg/wrappers/reconciler.go
+++ b/pkg/wrappers/reconciler.go
@@ -1,0 +1,81 @@
+package wrappers
+
+/*
+
+# Time your Reconcile.
+
+## Usage
+
+### Create the metric
+reconcileTimer := NewReconcileTimer("wizbang-operator")
+
+### Include the metric in your builder
+metricsServer := metrics.NewBuilder().WithCollector(reconcileTimer)
+
+### Wrap your Reconciler implementation when bootstrapping your controller
+reconciler := &TimedReconciler{
+	WrappedReconciler: &ReconcileWiz{ ... },
+	Metric:            reconcileTimer,
+	ControllerName:    "wiz-controller",
+	Logger:            logf.Log...,
+}
+
+### Profit
+\o/
+
+*/
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewReconcileTimer produces a HistogramVec Collector that records the duration of a Reconcile,
+// labeled by controller.
+// The Collector's name is {prefix}_reconcile_duration_seconds, where the {prefix} is derived from
+// the operatorName parameter.
+func NewReconcileTimer(operatorName string) *prometheus.HistogramVec {
+	name := fmt.Sprintf("%s_reconcile_duration_seconds", strings.ReplaceAll(operatorName, "-", "_"))
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        name,
+		Help:        "Distribution of the number of seconds a Reconcile takes, broken down by controller",
+		ConstLabels: prometheus.Labels{"name": operatorName},
+		Buckets:     []float64{0.001, 0.01, 0.1, 1, 5, 10, 20},
+	}, []string{"controller"})
+}
+
+// TimedReconciler is a wrapper that times how long Reconcile takes and reports it through the
+// provided `metric`. Use the result of `NewReconcileTimer` in the `Metric` field.
+type TimedReconciler struct {
+	WrappedReconciler reconcile.Reconciler
+	Metric            *prometheus.HistogramVec
+	ControllerName    string
+	Logger            logr.Logger
+}
+
+// Reconcile implements the Reconciler interface, timing the wrapped Reconciler's Reconcile call
+// and reporting that metric. Also logs bracketing messages, where the closing message includes
+// the duration of the wrapped Reconcile.
+func (r *TimedReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	logger := r.Logger.
+		WithValues(
+			"Controller", r.ControllerName,
+			"Request.Namespace", req.Namespace,
+			"Request.Name", req.Name,
+		)
+	logger.Info("Reconciling")
+
+	start := time.Now()
+	result, err := r.WrappedReconciler.Reconcile(req)
+	dur := time.Since(start)
+	r.Metric.WithLabelValues(r.ControllerName).Observe(dur.Seconds())
+
+	logger.WithValues("Duration", dur).Info("Reconcile complete")
+	return result, err
+}

--- a/pkg/wrappers/reconciler_test.go
+++ b/pkg/wrappers/reconciler_test.go
@@ -1,0 +1,71 @@
+package wrappers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	pcm "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestTimedReconciler(t *testing.T) {
+	const (
+		controllerName = "the-controller"
+	)
+
+	rt := NewReconcileTimer("op-name")
+	tr := &TimedReconciler{
+		WrappedReconciler: &testReconciler{},
+		ControllerName:    controllerName,
+		Logger:            log.Log,
+		Metric:            rt,
+	}
+
+	res, err := tr.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"}})
+
+	if !res.Requeue {
+		t.Fatal("Expected requeue!")
+	}
+	if err == nil {
+		t.Fatal("Expected an error!")
+	}
+	expectedErr := "Failed to reconcile bar/foo"
+	if err.Error() != expectedErr {
+		t.Fatalf("Wrong error message\nExpected: %q\nActual:   %q", expectedErr, err.Error())
+	}
+
+	observer, err := rt.GetMetricWith(prometheus.Labels{"controller": controllerName})
+	if err != nil {
+		t.Fatalf("Failed to get metric: %s", err.Error())
+	}
+	hg := observer.(prometheus.Histogram)
+
+	actualDesc := hg.Desc().String()
+	expectedDesc := `Desc{fqName: "op_name_reconcile_duration_seconds", help: "Distribution of the number of seconds a Reconcile takes, broken down by controller", constLabels: {name="op-name"}, variableLabels: [controller]}`
+	if actualDesc != expectedDesc {
+		t.Fatalf("Wrong description\nExpected: %q\nActual:   %q", expectedDesc, actualDesc)
+	}
+
+	metric := &pcm.Metric{}
+	hg.Write(metric)
+	if *metric.Histogram.SampleCount != 1 {
+		t.Fatalf("Expected one count but got %d", *metric.Histogram.SampleCount)
+	}
+	actualSeconds := metric.Histogram.GetSampleSum()
+	if actualSeconds < (time.Millisecond * 5).Seconds() {
+		t.Fatalf("Expected reconcile to take at least 5ms but it took %f", actualSeconds)
+	}
+}
+
+type testReconciler struct{}
+
+func (tr *testReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	// We can't rely on the Reconcile taking an exact amount of time; just make sure it's not zero
+	time.Sleep(time.Millisecond * 5)
+	// Deliberately contrived returns, just to prove the arguments make the full round trip
+	return reconcile.Result{Requeue: true}, fmt.Errorf("Failed to reconcile %s/%s", req.Namespace, req.Name)
+}


### PR DESCRIPTION
Introduces a `wrappers` module intended to house convenient metrics-related wrappers around common artifacts used by operators, controllers, and other k8s client-ish programs.

Adds the first such wrapper, designed for use with controller-runtime Reconciler implementations:
- `NewReconcileTimer` produces a standardized `HistogramVec` for timing/counting how long a `Reconcile` takes.
- `TimedReconciler` is an implementation of `Reconciler` that wraps another `Reconciler`, times its `Reconcile`, and `Observe`s its duration into such a metric.

Jira: [OSD-4596](https://issues.redhat.com/browse/OSD-4596)