### PR TITLE
Add builder function to specify Prometheus registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The user can provide the collectors which are to be registered with prometheus. 
 - Record metrics function:
 This is a user-defined function which describes the process in which the custom metrics are to be collected. This can be passed to the library or can be executed within the operator code based on the desired implementation.
 
+- Metrics Registry
+By default the libary uses the default Prometheus metrics registry to store metrics. This can be customized to use a specific metrics registry.
+
 ## Prerequisites
 The library can be integrated by downloading the same, using the following command:
 
@@ -42,4 +45,5 @@ The following functions of the library can be called by the user to create a met
 3. `WithPath(path string)` - Updates the default value of path in the metricsConfig object.
 4. `WithCollector(collector prometheus.Collector)` - Creates a list of prometheus collectors which are to be registered.
 5. `WithCollectors([]prometheus.Collector)` - Updates the list of collectors in the metricsConfig object.
-6. `GetConfig()` - Returns the reference to metricsConfig which is built with the configuration set by the user.
+6. `WithRegistry(registry *prometheus.Registry)` - Specify a registry to store collected metrics.
+7. `GetConfig()` - Returns the reference to metricsConfig which is built with the configuration set by the user.

--- a/example/example.go
+++ b/example/example.go
@@ -10,13 +10,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//Metrics endpoint and path which is to be used to expose metrics.
+// Metrics endpoint and path which is to be used to expose metrics.
 const (
 	metricsEndPoint = "8080"
 	metricsPath     = "/metrics"
 )
 
-//Metric variables which are to be collected.
+// Metric variables which are to be collected.
 var (
 	opsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "myapp_processed_ops_total",
@@ -38,13 +38,15 @@ func RecordMetrics() {
 	}()
 }
 
-//TestConfigMetrics creates a metricsConfig object and passes its reference to the library.
+// TestConfigMetrics creates a metricsConfig object and passes its reference to the library.
 func TestConfigMetrics() {
+	registry := prometheus.NewRegistry()
 	prTest := metrics.NewBuilder("test-namespace", "example-metrics-service").
 		WithPort(metricsEndPoint).
 		WithPath(metricsPath).
 		WithCollectors(metricsList).
 		WithRoute().
+		WithRegistry(registry).
 		GetConfig()
 
 	// Start metrics server with the exposed metrics.

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -65,6 +65,13 @@ func (b *metricsConfigBuilder) WithCollectors(collectors []prometheus.Collector)
 	return b
 }
 
+// WithRegistry allows specifying the prometheus registry to use for metrics. Other the default prometheus registry is used.
+func (b *metricsConfigBuilder) WithRegistry(registry *prometheus.Registry) *metricsConfigBuilder {
+	b.config.metricsRegisterer = registry
+	b.config.metricsGatherer = registry
+	return b
+}
+
 func (b *metricsConfigBuilder) WithRoute() *metricsConfigBuilder {
 	b.config.withRoute = true
 	return b

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -6,6 +6,8 @@ import "github.com/prometheus/client_golang/prometheus"
 type metricsConfig struct {
 	metricsPath        string
 	metricsPort        string
+	metricsRegisterer  prometheus.Registerer
+	metricsGatherer    prometheus.Gatherer
 	serviceName        string
 	collectorList      []prometheus.Collector
 	withRoute          bool

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -142,7 +142,11 @@ func GenerateRoute(s *v1.Service, path string) *routev1.Route {
 func ConfigureMetrics(ctx context.Context, userMetricsConfig metricsConfig) error {
 	log.Info("Starting prometheus metrics")
 
-	StartMetrics(userMetricsConfig)
+	err := StartMetrics(userMetricsConfig)
+	if err != nil {
+		log.Info("Error starting metrics server ", "Error", err.Error())
+		return err
+	}
 
 	client, err := createClient()
 	if err != nil {


### PR DESCRIPTION
The library currently uses the [default registry](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus?tab=doc#pkg-variables) to register all metrics. Some users may wish to override this by specifying a [Registry](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus?tab=doc#Registry) which contains metrics from other sources, for example the [controller-runtime registry](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/metrics/registry.go).

If no registry is specified then the default register and gatherer interfaces are used which means that any existing users who register their metrics directly will keep existing behavior.