### PR TITLE
Error when port & path are already bound

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,7 +38,23 @@ func StartMetrics(config metricsConfig) error {
 	http.Handle(config.metricsPath, metricsHandler)
 	log.Info(fmt.Sprintf("Port: %s", config.metricsPort))
 	metricsPort := ":" + (config.metricsPort)
-	go http.ListenAndServe(metricsPort, nil)
+
+	errc := make(chan error)
+	go ListenAndServeHandle(metricsPort, errc)
+	errMsg := <-errc
+	if errMsg != nil {
+		return errMsg
+	}
+	return nil
+}
+
+// ListenAndServeHandle takes in metricsPort and a channel for error
+func ListenAndServeHandle(metricsPort string, errc chan error) error {
+	err := http.ListenAndServe(metricsPort, nil)
+	if err != nil {
+		errc <- err
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
#30 
Currently, when port + path is already bound in ListenAndServe, our metrics fail silently without showing errors.

**Testing:**
I tested this using manual deployment of the cloud-ingress-operator. Below are the steps to set this up.

1. In main.go of the operator, make sure that our metrics are exposed on port 8080 and path at /metrics.
2. Deploy the operator so that it is running as a pod.
3. Look at the beginning of the operator pod log. In my case, I see 
`{"level":"info","ts":1601409508.1342049,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":1601409508.1347222,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1601409508.1351762,"logger":"userMetrics","msg":"Starting prometheus metrics"}
{"level":"info","ts":1601409508.1352267,"logger":"userMetrics","msg":"Port: 8080"}
{"level":"info","ts":1601409508.1353025,"logger":"userMetrics","msg":"Error starting metrics server ","Error":"Binding to port failed listen tcp :8080: bind: address already in use"}
{"level":"error","ts":1601409508.1353126,"logger":"cmd","msg":"Failed to configure OSD metrics","error":"Binding to port failed listen tcp :8080: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpk
g/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/workdir/cmd/manager/main.go:147\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
{"level":"info","ts":1601409508.1353493,"logger":"cmd","msg":"Starting the Cmd."}
{"level":"info","ts":1601409508.1354792,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1601409508.1355634,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"apischeme-controller","source":"kind source: /, Kind="}`
4. We can see that operator-sdk controller-runtime is on port 8080. Which now returns an error:
`{"level":"info","ts":1601409508.1353025,"logger":"userMetrics","msg":"Error starting metrics server ","Error":"Binding to port failed listen tcp :8080: bind: address already in use"}
{"level":"error","ts":1601409508.1353126,"logger":"cmd","msg":"Failed to configure OSD metrics","error":"Binding to port failed listen tcp :8080: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpk
g/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/workdir/cmd/manager/main.go:147\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}`
