### PR TITLE
Fixed blocking listen and serve which never returns

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,13 +36,16 @@ func StartMetrics(config metricsConfig) error {
 	metricsHandler := promhttp.InstrumentMetricHandler(
 		config.metricsRegisterer, promhttp.HandlerFor(config.metricsGatherer, promhttp.HandlerOpts{}),
 	)
-	http.Handle(config.metricsPath, metricsHandler)
 	log.Info(fmt.Sprintf("Port: %s", config.metricsPort))
-	metricsPort := ":" + (config.metricsPort)
-	if free := isPortFree(metricsPort); !free{
+	metricsPort := fmt.Sprintf(":%s", config.metricsPort)
+	if free := isPortFree(metricsPort); !free {
 		return fmt.Errorf("port %s is not free", config.metricsPort)
 	}
-	go http.ListenAndServe(metricsPort, nil)
+	server := &http.Server{
+		Addr:    metricsPort,
+		Handler: metricsHandler,
+	}
+	go server.ListenAndServe()
 	return nil
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// GetFreePort asks the kernel for a free open port that is ready to use.
+func getFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+	return fmt.Sprintf(":%d", l.Addr().(*net.TCPAddr).Port), nil
+}
+
+func TestCheckOpenTCPPortUsed(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Errorf("failed to get free port on host: %v", err)
+		return
+	}
+	_, err = net.Listen("tcp", freePort)
+	if err != nil {
+		t.Errorf("failed to listen on free port %s: %v", freePort, err)
+		return
+	}
+	if isPortFree(freePort) {
+		t.Errorf("address %s is is not actually free", freePort)
+	}
+}
+
+func TestCheckOpenTCPPortFree(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Errorf("failed to get free port")
+		return
+	}
+	if !isPortFree(freePort) {
+		t.Errorf("port %s is actually free", freePort)
+	}
+}


### PR DESCRIPTION
#33 breaks the `ConfigureMetrics()` function because it never returns. `StartMetrics()` which is in the call stack never returns because the error channel read is a blocking operation. I've instead changed the `StartMetrics` to check if the port in the question is free before starting the metrics server. Also added a test for the function.

This PR also contains the following changes:
- Refactored the `StartMetrics()` function to use a separate HTTP server instead of the default one which would conflict with anyone else trying to the use the default http server.
- Added tests for `isPortFree()` and `StartMetrics()`