### PR TITLE
Make default metrics path valid

### DIFF
--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -8,7 +8,7 @@ import (
 
 // Default variables for metrics-path and metrics-port.
 const (
-	defaultMetricsPath = "/customMetrics"
+	defaultMetricsPath = "/custommetrics"
 	defaultMetricsPort = "8089"
 )
 


### PR DESCRIPTION
# Description

The default metricsPath is invalid.

# Steps on how to test this PR 

Use the default path. 

```
{"level":"info","ts":1615336317.2273958,"logger":"userMetrics","msg":"Error getting current metrics service","Error":"Service \"managed-upgrade-operator-custom-metrics\" is invalid: spec.ports[0].name: Invalid value: \"customMetrics\": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"}
{"level":"error","ts":1615336317.2274911,"logger":"cmd","msg":"Failed to configure Metrics","error":"Service \"managed-upgrade-operator-custom-metrics\" is invalid: spec.ports[0].name: Invalid value: \"customMetrics\": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/dofinn/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/home/dofinn/go/src/github.com/openshift/managed-upgrade-operator/cmd/manager/main.go:192\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:225"}
FATA[0014] Failed to run operator locally: failed to run operator locally: failed to exec []string{"build/_output/bin/managed-upgrade-operator-local"}: exit status 1
```

versions

```
go version go1.16 linux/amd64
operator-sdk version: "v0.17.2", commit: "0258db0119e8e18e15d035532427c329fce1e871", kubernetes version: "v1.17.2", go version: "go1.16 linux/amd64"
```

Change to `custommetrics` for validation.