### PR TITLE
Register the monitoring scheme when setting up k8s client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
+	k8s.io/client-go v0.23.0
 	sigs.k8s.io/controller-runtime v0.11.1
 )
 
@@ -44,7 +45,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/client-go v0.23.0 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -301,7 +302,12 @@ func createClient() (client.Client, error) {
 		return nil, err
 	}
 
-	client, err := client.New(config, client.Options{})
+	err = monitoringv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

This PR ensures that the OpenShift monitoring v1 types are registered as part of initializing the kube client that is used for service/servicemonitor creation.

It was discovered during OperatorSDK v1.x migration effort that this was not happening, which otherwise requires a somewhat non-obvious workaround process of having consuming operator register it to the client-go [Scheme](https://pkg.go.dev/k8s.io/client-go/kubernetes/scheme).
