### PR TITLE
Removing user Dofinn from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,6 @@
 approvers:
 - fahlmant
 - rafael-azevedo
-- dofinn
 reviewers:
 - fahlmant
 - rafael-azevedo
-- dofinn


### PR DESCRIPTION
# Description
This PR serves the purpose of removing user Dofinn from owners as he has left Red Hat

# Related issue/bug/feature request
https://issues.redhat.com/browse/OHSS-15434

# Steps on how to test this PR
 
